### PR TITLE
upd: Blocking screen orientation to sensorPortrait mode

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,9 +15,12 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
         tools:ignore="GoogleAppIndexingWarning">
-        <activity android:name=".connexion.FirstConnexionActivity" />
-        <activity android:name=".connexion.ConnexionActivity" />
-        <activity android:name=".MainActivity">
+        <activity android:name=".connexion.FirstConnexionActivity"
+            android:screenOrientation="sensorPortrait"/>
+        <activity android:name=".connexion.ConnexionActivity"
+            android:screenOrientation="sensorPortrait"/>
+        <activity android:name=".MainActivity"
+            android:screenOrientation="sensorPortrait">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 


### PR DESCRIPTION
Blocking landscape mode by setting screen orientation to `sensorPortrait` mode.

It is working for me, but tests by other people need to be done.